### PR TITLE
chore: exclude development files from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,15 @@ test-helpers.*
 
 claude.md
 *.png
+
+# Development documentation (내부 개발 문서 - GitHub 제외)
+CLAUDE.md
+emergency-security-measures.md
+SUPABASE_NEW_API_KEYS_REFERENCE.md
+MOBILE_UI_TODO.md
+
+# Claude Desktop local settings (로컬 개발 환경)
+.claude/
+
+# Playwright MCP test artifacts (테스트 아티팩트)
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Updated `.gitignore` to exclude development-specific files from version control
- Prevents internal documentation and local configuration files from being pushed to GitHub

## Changes Made
- **Added to .gitignore:**
  - Internal documentation files (CLAUDE.md, emergency-security-measures.md, etc.)
  - Claude Desktop local settings directory (.claude/)
  - Playwright MCP test artifacts (.playwright-mcp/)

## Why These Changes?
These files contain:
- Development-specific configurations
- Internal documentation not relevant to public users
- Test artifacts and screenshots
- Local IDE settings

All excluded files remain available locally for developers but won't clutter the public repository.

## Test Plan
- [x] Verified .gitignore syntax is correct
- [x] Confirmed files are still accessible locally
- [x] Tested that new files in these directories are ignored
- [x] Ensured README.md remains tracked (public documentation)

🤖 Generated with [Claude Code](https://claude.ai/code)