### PR TITLE
chore: cleanup dependencies and improve gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,9 @@ test-helpers.*
 check_*.mjs
 check-*.mjs
 test_*.mjs
+scripts/test-*.mjs
+scripts/create-test-*.mjs
+scripts/*-test.mjs
 
 # Test artifacts and screenshots only (not all PNGs)
 .playwright-mcp/**/*.png

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
-        "dotenv": "^17.2.1",
         "es-toolkit": "^1",
         "framer-motion": "^11",
         "js-yaml": "^4.1.0",
@@ -8040,18 +8039,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
-    "dotenv": "^17.2.1",
     "es-toolkit": "^1",
     "framer-motion": "^11",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
## Summary
- Remove unused `dotenv` dependency that was temporarily added for test scripts
- Enhance `.gitignore` patterns to prevent accidental commits of test scripts
- Improve project security by blocking `scripts/test-*.mjs` patterns

## Changes
- 🗑️ Removed `dotenv` from package.json dependencies
- 📝 Added test script patterns to `.gitignore`:
  - `scripts/test-*.mjs`
  - `scripts/create-test-*.mjs`
  - `scripts/*-test.mjs`

## Test Plan
- [x] Verified dotenv is not used anywhere in the codebase
- [x] Confirmed test scripts are properly ignored by git
- [x] Package lock file updated correctly

## Notes
This cleanup was done after creating test accounts for the application. The test scripts have been removed and gitignore patterns added to prevent future accidental commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 유지보수(Chores)
  * scripts 디렉터리의 테스트용 mjs 스크립트를 버전 관리에서 제외하도록 .gitignore 패턴을 추가했습니다.
  * 불필요한 dotenv 패키지를 의존성에서 제거해 설치 크기와 보안 표면을 소폭 줄였습니다.
  * 런타임 동작 또는 사용자 기능에는 영향이 없으며, 기존 사용 흐름은 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->