### PR TITLE
🔥 HOTFIX: 스케줄 수정 기능 긴급 수정

### DIFF
--- a/src/components/schedules/schedule-edit-modal.tsx
+++ b/src/components/schedules/schedule-edit-modal.tsx
@@ -142,7 +142,14 @@ export function ScheduleEditModal({
   }
 
   const editMutation = useMutation({
-    mutationFn: (data: ScheduleEditInput) => scheduleService.editSchedule(schedule.schedule_id, data),
+    mutationFn: (data: ScheduleEditInput) => {
+      console.log('[ScheduleEditModal] Calling editSchedule with:', {
+        schedule_id: schedule.schedule_id,
+        data,
+        fullSchedule: schedule
+      })
+      return scheduleService.editSchedule(schedule.schedule_id, data)
+    },
     onSuccess: () => {
       // scheduleServiceEnhanced의 캐시도 클리어하고 이벤트 발행
       scheduleServiceEnhanced.clearCache()

--- a/src/components/schedules/schedule-edit-modal.tsx
+++ b/src/components/schedules/schedule-edit-modal.tsx
@@ -143,11 +143,15 @@ export function ScheduleEditModal({
 
   const editMutation = useMutation({
     mutationFn: (data: ScheduleEditInput) => {
-      console.log('[ScheduleEditModal] Calling editSchedule with:', {
-        schedule_id: schedule.schedule_id,
-        data,
-        fullSchedule: schedule
-      })
+      // Only log non-PHI identifiers in development
+      if (process.env.NODE_ENV === 'development') {
+        console.log('[ScheduleEditModal] Calling editSchedule:', {
+          schedule_id: schedule.schedule_id,
+          has_data: !!data,
+          // Only log field presence, not actual values
+          fields_to_update: data ? Object.keys(data) : []
+        })
+      }
       return scheduleService.editSchedule(schedule.schedule_id, data)
     },
     onSuccess: () => {

--- a/src/services/scheduleServiceEnhanced.ts
+++ b/src/services/scheduleServiceEnhanced.ts
@@ -139,6 +139,8 @@ export class ScheduleServiceEnhanced {
         // Transform from flattened RPC format to nested format
         // Keep both snake_case and camelCase for backward compatibility
         return {
+          // CRITICAL: Map schedule_id for ScheduleWithDetails type compatibility
+          schedule_id: s.schedule_id || s.id,  // UI expects schedule_id
           // Main schedule properties with both naming conventions
           // Prefer s.id (DB primary key if present), then s.schedule_id (RPC renamed PK), then composite fallback
           id: s.id || s.schedule_id || `${s.patient_id}-${s.item_id}-temp`,
@@ -334,6 +336,8 @@ export class ScheduleServiceEnhanced {
 
         // Transform the data to match expected format used by UI
         return (schedules || []).map(s => ({
+          // Map 'id' to 'schedule_id' to match ScheduleWithDetails type
+          schedule_id: s.id,  // IMPORTANT: UI expects schedule_id, not id
           // Keep both naming conventions for compatibility
           id: s.id,
           patient_id: s.patient_id,
@@ -350,6 +354,14 @@ export class ScheduleServiceEnhanced {
           createdAt: s.created_at,
           updated_at: s.updated_at,
           updatedAt: s.updated_at,
+          // Add flat fields for UI compatibility
+          patient_name: s.patients?.name || '',
+          patient_care_type: s.patients?.care_type || '',
+          patient_number: s.patients?.patient_number || '',
+          item_name: s.items?.name || '',
+          item_category: s.items?.category || '',
+          doctor_id: s.patients?.doctor_id || null,
+          doctor_name: null, // Not available in direct query
           // Nested patient object
           patient: s.patients ? {
             id: s.patients.id,


### PR DESCRIPTION
## 🚨 긴급 수정 (HOTFIX)

### 📋 문제 설명
스케줄 수정 버튼 클릭 시 다음 오류 발생:
- "스케줄을 찾을 수 없습니다" 에러
- 수정 모달에서 item(검사/주사 항목)이 표시되지 않음

### 🔍 원인 분석

1. **ID 필드명 불일치**
   - RPC 함수(`get_filtered_schedules`, `get_today_checklist`)는 `schedule_id`로 반환
   - 실제 schedules 테이블의 primary key는 `id`
   - fallback 로직에서 이 매핑이 누락됨

2. **데이터 구조 불일치**  
   - `ScheduleWithDetails` 타입은 `schedule_id` 필드를 기대
   - fallback 쿼리는 `id` 필드만 반환하여 불일치 발생

### ✅ 해결 방법

#### 1. scheduleServiceEnhanced.ts 수정
- `getTodayChecklist` fallback: `id` → `schedule_id` 매핑 추가
- `getFilteredSchedules`: `schedule_id` 필드 보장
- 누락된 플랫 필드 추가 (`patient_name`, `item_name` 등)

#### 2. 디버깅 로그 추가
- `scheduleService.editSchedule`: 상세 로깅
- `ScheduleEditModal`: 데이터 전달 로깅
- ⚠️ 프로덕션 배포 전 제거 필요

### 📊 영향 범위
- ✅ 대시보드 스케줄 수정 기능 복구
- ✅ 스케줄 편집 모달 정상 작동
- ✅ 기존 데이터 무결성 유지

### 🧪 테스트 완료
- [x] 스케줄 수정 모달 열기
- [x] item 필드 정상 표시
- [x] 메모 수정 및 저장
- [x] 주기 변경 테스트
- [x] 다음 예정일 변경

### 📝 추가 작업 필요
- [ ] 디버깅 로그 제거 (프로덕션 전)
- [ ] completions 테이블 생성 (get_today_checklist RPC 함수용)
- [ ] TypeScript 타입 정합성 개선

### 🔄 배포 우선순위
**🔴 긴급** - 프로덕션 주요 기능 장애

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * 체크리스트·일정 항목의 식별자 매핑을 정교화하여 간헐적 누락/오매칭을 개선했습니다.
  * 환자 이름, 케어 타입, 환자번호, 의사 이름/ID, 항목명/카테고리가 화면 전반에서 더 일관되게 표시됩니다.
* Refactor
  * 데이터 변환 로직을 정리해 화면 간 정보 일치성과 유지보수성을 높였습니다.
* Chores
  * 진단·오류 로그를 확장해 문제 추적과 디버깅을 용이하게 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->